### PR TITLE
Removed sbt-bintray-bundle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,10 +101,5 @@ def project(id: String) = Project(id, base = file(id))
 // do not delete database files on start
 lagomCassandraCleanOnStart in ThisBuild := false
 
-// set up information for where to publish our bundles to
-// (see http://conductr.lightbend.com/docs/1.1.x/CreatingBundles#Publishing-bundles for more
-// information)
 licenses in ThisBuild := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
-bintrayVcsUrl in Bundle in ThisBuild := Some("https://github.com/lagom/activator-lagom-scala-chirper")
-bintrayOrganization in Bundle in ThisBuild := Some("typesafe")
-bintrayReleaseOnPublish in Bundle in ThisBuild := true
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-bintray-bundle" % "1.0.2")
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "3.0.0")
 addSbtPlugin("com.github.ddispaltro" % "sbt-reactjs" % "0.5.2")
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.4")


### PR DESCRIPTION
Reason is that lack of credentials leads to warnings (and possibly even
errors?) when running chirper. See issue 26 on
https://github.com/lagom/activator-lagom-java-chirper for context.
