### PR TITLE
Add `liftToHeaderServiceCall` implicit converter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,10 @@ lazy val loadTestImpl = project("load-test-impl")
 lazy val utils = project("utils")
   .settings(
     version := "1.0-SNAPSHOT",
-    libraryDependencies += lagomJavadslApi
+    libraryDependencies ++= Seq(
+      lagomJavadslApi,
+      lagomJavadslServer
+    )
   )
 
 def project(id: String) = Project(id, base = file(id))

--- a/utils/src/main/scala/converter/ServiceCallConverter.scala
+++ b/utils/src/main/scala/converter/ServiceCallConverter.scala
@@ -5,11 +5,24 @@ package converter
 
 import java.util.concurrent.CompletionStage
 
+import akka.japi.Pair
 import com.lightbend.lagom.javadsl.api.ServiceCall
+import com.lightbend.lagom.javadsl.api.transport.{RequestHeader, ResponseHeader}
+import com.lightbend.lagom.javadsl.server.HeaderServiceCall
+
+import scala.concurrent.ExecutionContext
+import scala.language.implicitConversions
 
 object ServiceCallConverter extends CompletionStageConverters {
-  implicit def liftToServiceCall[Request, Response](f: Request => CompletionStage[Response]): ServiceCall[Request,Response] =
-    new ServiceCall[Request,Response] {
+  implicit def liftToServiceCall[Request, Response](f: Request => CompletionStage[Response]): ServiceCall[Request, Response] =
+    new ServiceCall[Request, Response] {
       def invoke(request: Request): CompletionStage[Response] = f(request)
-  }
+    }
+
+  implicit def liftToHeaderServiceCall[Request, Response](f: (RequestHeader, Request) => CompletionStage[Response])
+    (implicit ec: ExecutionContext): HeaderServiceCall[Request, Response] =
+      new HeaderServiceCall[Request, Response] {
+        override def invokeWithHeaders(requestHeader: RequestHeader, request: Request): CompletionStage[Pair[ResponseHeader, Response]] =
+          f(requestHeader, request).map(response => Pair.create(ResponseHeader.OK, response))
+      }
 }


### PR DESCRIPTION
Hi,

I found myself in the need of this converter. I think it could be useful to others.

I think that we can even improve these implicits, changing the `CompletionStage` by  a `Future` in the function passed as parameter (it's how I use them), like this:

``` scala
implicit def liftToServiceCall[Request, Response](f: Request => Future[Response]): ServiceCall[Request, Response]
```

``` scala
implicit def liftToHeaderServiceCall[Request, Response](f: (RequestHeader, Request) => Future[Response])(implicit ec: ExecutionContext): HeaderServiceCall[Request, Response]
```

What do you think ?
